### PR TITLE
feat: Update default value of 'blocked' attribute in user schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Before you can start using Strapi as your backend, you need to create an admin u
 
 ### 2024
 
+- 2024-03-22 - Update default value of `blocked` attribute in user schema [#9](https://github.com/jpcmf/Backend-GraduateProgram-FullStack-2023/pull/9) _(v0.1.4)_
 - 2024-03-21 - Add `@strapi/provider-email-nodemailer` to handle with sending emails [#8](https://github.com/jpcmf/Backend-GraduateProgram-FullStack-2023/pull/8) _(v0.1.3)_
 - 2024-03-19 - Add a quick guide to getting started with the application [#5](https://github.com/jpcmf/Backend-GraduateProgram-FullStack-2023/pull/5) _(v0.1.2)_
 - 2024-03-17 - Add `mysql2` to handle with database [#4](https://github.com/jpcmf/Backend-GraduateProgram-FullStack-2023/pull/4) _(v0.1.1)_

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "backend",
   "private": true,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "SkateHub Backend powered by Strapi",
   "scripts": {
     "develop": "strapi develop",

--- a/src/extensions/users-permissions/content-types/user/schema.json
+++ b/src/extensions/users-permissions/content-types/user/schema.json
@@ -55,7 +55,7 @@
     },
     "blocked": {
       "type": "boolean",
-      "default": false,
+      "default": true,
       "configurable": false
     },
     "role": {


### PR DESCRIPTION
This commit modifies the default value of the 'blocked' attribute in the user schema from false to true. Consequently, newly created users are now unable to log in to the application immediately after account creation. Access is granted only upon email address confirmation, initiated by the system. Additionally, administrators can manually update the 'blocked' attribute to false via the admin panel to enable user access.